### PR TITLE
Do not validate license if activation token does not exist.

### DIFF
--- a/src/Core/Activator.php
+++ b/src/Core/Activator.php
@@ -251,7 +251,7 @@ class Activator {
 		 * Find existing license?
 		 */
 		$token          = $this->configuration->getEntity()->getActivationToken();
-		$license        = $this->configuration->getClient()->prepareValidateLicense( $token );
+		$license        = $token ? $this->configuration->getClient()->prepareValidateLicense( $token ) : array();
 		$deactivated_at = isset( $license['deactivated_at'] ) ? $license['deactivated_at'] : false;
 		$is_expired     = isset( $license['license']['is_expired'] ) ? (bool) $license['license']['is_expired'] : true;
 		$is_deactivated = ! empty( $deactivated_at );


### PR DESCRIPTION
@gdarko,
This pull request prevents [`IdeoLogix\DigitalLicenseManagerUpdaterWP\Core\Activator::renderActivationForm()`](https://github.com/ideologix/dlm-wp-updater/blob/main/src/Core/Activator.php#L236) from attempting to validate the license when the activation token that does not exist.

Benefits:
1. Saves time not making an HTTP request that is doomed to fail.
2. Prevents the [Query Monitor](https://wordpress.org/plugins/query-monitor/) plugin from warning about a 404 HTTP API call.
