### PR TITLE
Add slug to plugin information if not returned by DLM software API.

### DIFF
--- a/src/Core/Updater.php
+++ b/src/Core/Updater.php
@@ -152,6 +152,10 @@ class Updater {
 			return $result;
 		}
 
+		if ( empty( $response['details']['slug'] ) ) {
+			$response['details']['slug'] = $slug;
+		}
+
 		$response = $this->format_details( $response );
 		if ( ! $response ) {
 			return $result;


### PR DESCRIPTION
The WordPress [`install_plugin_information()`](https://github.com/WordPress/WordPress/blob/6.0.2/wp-admin/includes/plugin-install.php#L515) function requires that the returned API response from `plugins_api()` has a `slug` property, used [here](https://github.com/WordPress/WordPress/blob/6.0.2/wp-admin/includes/plugin-install.php#L837).

Digital License Manager Pro does not return `slug` in the [software API](https://docs.codeverve.com/digital-license-manager/rest-api/software/single/). It should, but until it does, this pull request will add the slug to the plugin information if it is missing.

